### PR TITLE
status is now really linked to the renegotiation status

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -10,7 +10,8 @@ class Product < ApplicationRecord
   validates :description, presence: true
   validates :current_price, presence: true
   validates :contract_end_date, presence: true
-  # …
+
+  # … used in the SHOW page
   def sku
     "SKU-#{id.to_s.rjust(6,'0')}"
   end
@@ -26,4 +27,31 @@ class Product < ApplicationRecord
   def last_year_volume
     last_month_volume.to_f * 12
   end
+
+  # WHAT IT IS : below is the function to automatically update the status.
+    # So when you upload it it is pending = no renegotiation started
+    # then when the user clicks on renegotiation and a negotiation starts, it is "ongoing"
+    # if a user clicked on talk to a human it is "human required"
+    # when it is done it is "done"
+  def renegotiation_status
+    #If the product has no renegotiations (renegotiations.none?), we immediately return "pending".
+    return "pending" if renegotiations.none?
+
+    # here in case one product has multiple renegotiation, we sort them from newst to oldest and take the latest one
+    latest = renegotiations.order(created_at: :desc).first
+
+    case latest.status.to_s.downcase #We now look at the status of that latest renegotiation
+    when "human_required"
+      "human required"
+    when "ongoing", "initialized" #If the latest status is either "in_progress" or "initiated", return "ongoing".
+      "ongoing"
+    when "done" #If the renegotiation is marked "completed", the product is "done".
+      "done"
+    else
+      "pending"
+    end
+  end
+
+
+
 end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -50,7 +50,7 @@
           <td class="products-line-text"><%= product.last_month_volume %></td>
           <td class="products-line-text">
             <span class="status <%= product.status.downcase.tr(' ', '_') %>">
-              <%= product.status.capitalize %>
+              <%= product.renegotiation_status.titleize %>
             </span>
           </td>
           <td class="products-line-text">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,7 +94,7 @@ renegotiations = []
   max_target = current_price * 0.9  # 10% discount min
 
   renegotiations << Renegotiation.create!(
-    status: ["Initiated", "In Progress", "Completed", "Cancelled"].sample,
+    status: ["ongoing", "done", "Human required"].sample,
     thread: Faker::Quote.matz,
     tone: ["collaborative", "neutral", "aggressive"].sample,
     min_target: min_target,
@@ -154,9 +154,9 @@ demo_volumes = [5000, 8000, 15_000, 25_000, 30_000] # Realistic spending volumes
   )
 end
 
-# Create demo renegotiation
+# Create a demo renegotiation linked to the first product of walmart that is ongoing
 Renegotiation.create!(
-  status: "in_progress",
+  status: "ongoing",
   thread: "Hi! We'd love to discuss better terms for our contract renewal as loyal customers.",
   tone: "collaborative",
   min_target: 800,
@@ -166,6 +166,31 @@ Renegotiation.create!(
   buyer: demo_procurement1,
   supplier: demo_supplier
 )
+
+Renegotiation.create!(
+  status: "human_required",
+  thread: "Hi! We'd love to discuss better terms for our contract renewal as loyal customers.",
+  tone: "collaborative",
+  min_target: 800,
+  max_target: 900,
+  new_price: nil,
+  product: demo_products.second,
+  buyer: demo_procurement1,
+  supplier: demo_supplier
+)
+
+Renegotiation.create!(
+  status: "done",
+  thread: "Hi! We'd love to discuss better terms for our contract renewal as loyal customers.",
+  tone: "collaborative",
+  min_target: 800,
+  max_target: 900,
+  new_price: nil,
+  product: demo_products.third,
+  buyer: demo_procurement1,
+  supplier: demo_supplier
+)
+
 
 puts "✅ Created demo users and sample data"
 


### PR DESCRIPTION
The product status shown on the index page is no longer hardcoded. It now updates automatically based on whether there’s a renegotiation, and what its current status is (ongoing, human required, or done).